### PR TITLE
Bug in using argparse and multiple repetition of default values

### DIFF
--- a/yt_crawl.py
+++ b/yt_crawl.py
@@ -170,7 +170,7 @@ def parseAcademy():
         output.append(entry)
     return output
 
-def run(api_key, gitCommit, datasetOutputLocation="dataset.json"):
+def run(api_key, gitCommit, datasetOutputLocation):
     videos = []
     print("Parsing Academy Courses")
     output = parseAcademy()
@@ -229,7 +229,7 @@ def run(api_key, gitCommit, datasetOutputLocation="dataset.json"):
         gitDescription = "Updated dataset"
         print(f"Commiting to git, with commit description {gitDescription}")
         from subprocess import call
-#        call(["git", "commit", "-m", gitDescription, datasetOutputLocation])
+        call(["git", "commit", "-m", gitDescription, datasetOutputLocation])
     else:
         print("Done! Now commit to git")
 
@@ -246,16 +246,15 @@ def parser():
             help="The output path", 
             default="dataset.json")
     parser.add_argument(
-        '-g', '--git-commit',
-        help="Automatically commit the dataset file to git (uses git cli)", 
-        default=False, 
-        type=bool)
+        '-g', '--git_commit',
+        help="Automatically commit the dataset file to git (uses git cli)",
+        action='store_true')
     args = parser.parse_args()
     if not args.api_key:
         args.api_key = open('yt.secret').read()
 
-    run(args.api_key, args.output_file)
+    run(args.api_key, args.git_commit, args.output_file)
 
 
-if __name__ == "__main__":
+if(__name__ == "__main__"):
     parser()


### PR DESCRIPTION
Using the script I noticed that there was a bug in the commit automation script checking. The parameters had been reversed. Also, the commit flag, so to speak, the -g had wrong parameters that forced it to have an argument.

Furthermore, as explained in the issue, there is a need to change the readme, as it is incorrectly recommended to use the script. I recommend the following change: 
```bash
python yt_crawl.py -a "API_KEY_HERE" -g
```